### PR TITLE
fix: foreground notifications missing small icon

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNReceivedMessageHandler.java
@@ -55,12 +55,17 @@ public class RNReceivedMessageHandler {
             bundle.putString("sound", remoteNotification.getSound());
             bundle.putString("color", remoteNotification.getColor());
             bundle.putString("tag", remoteNotification.getTag());
-            
-            if(remoteNotification.getChannelId() != null) {
-              bundle.putString("channelId", remoteNotification.getChannelId());
+
+            if(remoteNotification.getIcon() != null) {
+                bundle.putString("smallIcon", remoteNotification.getIcon());
+            } else {
+               bundle.putString("smallIcon", "ic_notification");
             }
-            else {
-              bundle.putString("channelId", config.getNotificationDefaultChannelId());
+
+            if(remoteNotification.getChannelId() != null) {
+                bundle.putString("channelId", remoteNotification.getChannelId());
+            } else {
+                bundle.putString("channelId", config.getNotificationDefaultChannelId());
             }
 
             Integer visibilty = remoteNotification.getVisibility();


### PR DESCRIPTION
## Description
import [PR](https://github.com/zo0r/react-native-push-notification/pull/1927) from original repo