### PR TITLE
fix: set key with value on frozen object

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,10 @@ Notifications.localNotification = function ({ ...details }) {
   }
 
   if (details.userInfo) {
-    details.userInfo.id = details.userInfo.id || details.id;
+    details.userInfo = {
+      ...details.userInfo,
+      id: details.userInfo.id || details.id
+    };
   } else {
     details.userInfo = { id: details.id };
   }


### PR DESCRIPTION
## Description
Fix the following error:

```
You attempted to set the key id with the value undefined on an object that is meant to be immutable and has been frozen. 
```

This issue is caused by the object which is passed with frozen status, so we recreate object container and spreads all the props inside the object.


## Related Issue
https://github.com/zo0r/react-native-push-notification/issues/2044