### PR TITLE
fix: cannot handle notification on android

### DIFF
--- a/component/index.android.js
+++ b/component/index.android.js
@@ -62,7 +62,8 @@ class NotificationsComponent {
   static checkPermissions(callback) {
     RNPushNotification.checkPermissions().then(alert => callback({ alert }));
   }
-  addEventListener(type, handler) {
+
+  static addEventListener(type, handler) {
     let listener;
     if (type === 'notification') {
       listener = DeviceEventEmitter.addListener(


### PR DESCRIPTION
## Description
Cannot attach listener on Android because handler belongs to instance not static one

## Related Issue