### PR TITLE
fix: do not mutate frozen object

### DIFF
--- a/index.js
+++ b/index.js
@@ -240,7 +240,10 @@ Notifications.localNotificationSchedule = function ({ ...details }) {
   }
 
   if (details.userInfo) {
-    details.userInfo.id = details.userInfo.id || details.id;
+    details.userInfo = {
+      ...details.userInfo,
+      id: details.userInfo.id || details.id
+    };
   } else {
     details.userInfo = { id: details.id };
   }


### PR DESCRIPTION
## Description

Fix the following error when firing schedule notification twice:

```
You attempted to set the key id with the value undefined on an object that is meant to be immutable and has been frozen. 
```

This issue is caused by the object which is passed with frozen status, so we recreate object container and spreads all the props inside the object.

## Related Issue
#8 