### PR TITLE
imp: request permissions and wait until it is resolved

### DIFF
--- a/component/index.android.js
+++ b/component/index.android.js
@@ -22,7 +22,7 @@ class NotificationsComponent {
   }
 
   static requestPermissions() {
-    RNPushNotification.requestPermissions();
+    return RNPushNotification.requestPermissions();
   }
 
   static subscribeToTopic(topic) {


### PR DESCRIPTION
## Description
`requestPermissions` 하면 안드로이드의 경우 synchronous하게 콜하고 토큰만 가져오고 종료되는데 promise로 상태를 resolve 해서 iOS와 동작이 동일하게 가도록 변경합니다.

## Related Issue