### PR TITLE
fix: fix to triggerDate daily for schedule local notification when set to repeats

### DIFF
--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -56,12 +56,10 @@ RCT_ENUM_CONVERTER(NSCalendarUnit,
     NSDate* fireDate = [RCTConvert NSDate:details[@"fireDate"]];
     BOOL repeats = [RCTConvert BOOL:details[@"repeats"]];
     NSDateComponents *triggerDate = fireDate ? [[NSCalendar currentCalendar]
-                                                components:NSCalendarUnitYear +
-                                                NSCalendarUnitMonth + NSCalendarUnitDay +
-                                                NSCalendarUnitHour + NSCalendarUnitMinute +
-                                                NSCalendarUnitSecond + NSCalendarUnitTimeZone
-                                                fromDate:fireDate] : nil;
-    
+                                                components:NSCalendarUnitHour +
+                                                NSCalendarUnitMinute + NSCalendarUnitSecond +
+                                                NSCalendarUnitTimeZone fromDate:fireDate] : nil;
+
     UNCalendarNotificationTrigger* trigger = triggerDate ? [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:triggerDate repeats:repeats] : nil;
 
     UNNotificationRequest* notification = [UNNotificationRequest requestWithIdentifier:identifier content:content trigger:trigger];


### PR DESCRIPTION
## Description

반복적인 schedule local notification 을 특정 date 로 설정하고 특정 date 가 지나가면 triggerDate 가 daily 단위로 현 시점기준으로 다음 미래의 tiggerDate 로 설정이 되지 않고 nil 로 설정이 되는것에 대한 버그 수정

## Related Issue
- https://developer.apple.com/documentation/usernotifications/uncalendarnotificationtrigger?language=objc
- https://developer.apple.com/documentation/usernotifications/scheduling_a_notification_locally_from_your_app?language=objc
- https://useyourloaf.com/blog/local-notifications-with-ios-10