### PR TITLE
fix: [iOS] fix for triggerDate on specific day for schedule local notification

### DIFF
--- a/ios/RCTConvert+Notification.m
+++ b/ios/RCTConvert+Notification.m
@@ -112,10 +112,13 @@ RCT_ENUM_CONVERTER(UIBackgroundFetchResult, (@{
 
     NSDate* fireDate = [RCTConvert NSDate:details[@"fireDate"]];
     BOOL repeats = [RCTConvert BOOL:details[@"repeats"]];
-    NSDateComponents *triggerDate = fireDate ? [[NSCalendar currentCalendar]
-                                                components:NSCalendarUnitHour +
-                                                NSCalendarUnitMinute + NSCalendarUnitSecond +
-                                                NSCalendarUnitTimeZone fromDate:fireDate] : nil;
+
+    NSCalendarUnit calendarComponents = NSCalendarUnitHour + NSCalendarUnitMinute + NSCalendarUnitSecond + NSCalendarUnitTimeZone;
+    if (!repeats) {
+      calendarComponents = calendarComponents + NSCalendarUnitYear + NSCalendarUnitMonth + NSCalendarUnitDay;
+    }
+
+    NSDateComponents *triggerDate = fireDate ? [[NSCalendar currentCalendar] components: calendarComponents fromDate:fireDate] : nil;
 
     UNCalendarNotificationTrigger* trigger = triggerDate ? [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:triggerDate repeats:repeats] : nil;
 


### PR DESCRIPTION
특정한 날짜에 local notification 을 등록하려면 calendarUnit 에 NSCalendarUnitYear + NSCalendarUnitMonth + NSCalendarUnitDay 을 추가하여야 합니다.

단, daily 로 반복 되는 local notification 에는 NSCalendarUnitYear + NSCalendarUnitMonth + NSCalendarUnitDay 이 추가가 되지 않아야 합니다.

### Reference
https://radish.atlassian.net/browse/RS-8190