### PR TITLE
fix: fix opening app issue

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -107,7 +107,7 @@ public class RNPushNotificationHelper {
             notificationIntent.putExtra(RNPushNotificationPublisher.NOTIFICATION_ID, notificationID);
             notificationIntent.putExtras(bundle);
 
-            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
+            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
 
             return PendingIntent.getBroadcast(context, notificationID, notificationIntent, flags);
         } catch (Exception e) {
@@ -452,9 +452,9 @@ public class RNPushNotificationHelper {
 
             int notificationID = Integer.parseInt(notificationIdString);
 
-            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
+            int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ? PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE : PendingIntent.FLAG_UPDATE_CURRENT;
 
-            PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationID, intent, flags);
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, notificationID, intent, flags);
 
             NotificationManager notificationManager = notificationManager();
 


### PR DESCRIPTION
Android 에서 Notification 클릭시 앱이 열리지 않는 이슈를 수정합니다.

- 이전 PR에서 버전 분기 잘못된 부분 수정 (앱 열리지 않는 문제와는 무관)
https://github.com/radishmedia/react-native-push-notification/pull/19
- 앱을 실행 하기위한 MainActivity pending intent 생성 함수를 getBroadcast 에서 getActivity 로 변경 (앱 실행과 연관)
