### PR TITLE
fix: fix crash on android 12

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -172,6 +172,9 @@ public class RNPushNotificationHelper {
         Log.d(LOG_TAG, String.format("Setting a notification with id %s at time %s",
                 bundle.getString("id"), Long.toString(fireDate)));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !getAlarmManager().canScheduleExactAlarms()) {
+                return;
+            }
             if (allowWhileIdle && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 getAlarmManager().setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, fireDate, pendingIntent);
             } else {


### PR DESCRIPTION
안드로이드 12에서 앱설정에서 알람 및 리마인드 설정을 끌 경우 크래시 나는 문제를 수정합니다.

- android 12 이상 단말의 경우 해당 권한이 필요한 함수 호출 전에 체크하도록 코드 추가


https://developer.android.com/reference/android/app/AlarmManager#canScheduleExactAlarms()