### PR TITLE
fix: Prevent registration of scheduled notification to a past time

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -625,8 +625,11 @@ public class RNPushNotificationHelper {
             }
 
             long newFireDate;
+            long currentTime = Calendar.getInstance().getTimeInMillis();
             if ("time".equals(repeatType)) {
-                newFireDate = fireDate + repeatTime;
+                do {
+                    newFireDate = fireDate + repeatTime;
+                } while (newFireDate < currentTime);
             } else {
                 int repeatField = getRepeatField(repeatType);
 
@@ -634,9 +637,10 @@ public class RNPushNotificationHelper {
                 nextEvent.setTimeInMillis(fireDate);
                 // Limits repeat time increment to int instead of long
                 int increment = repeatTime > 0 ? (int) repeatTime : 1;
-                nextEvent.add(repeatField, increment);
-
-                newFireDate = nextEvent.getTimeInMillis();
+                do {
+                    nextEvent.add(repeatField, increment);
+                    newFireDate = nextEvent.getTimeInMillis();
+                } while (newFireDate < currentTime);
             }
 
             // Sanity check, should never happen

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -627,9 +627,10 @@ public class RNPushNotificationHelper {
             long newFireDate;
             long currentTime = Calendar.getInstance().getTimeInMillis();
             if ("time".equals(repeatType)) {
-                do {
-                    newFireDate = fireDate + repeatTime;
-                } while (newFireDate < currentTime);
+                newFireDate = fireDate + repeatTime;
+                if (newFireDate < currentTime) {
+                    newFireDate = currentTime + ((currentTime - fireDate) % repeatTime);
+                }
             } else {
                 int repeatField = getRepeatField(repeatType);
 


### PR DESCRIPTION
과거에 처리 되지 못한 Scheduled Local Notification 이 리부트 등으로 처리 될때 한번에 밀린 기간 동안의 Notification 이 단시간에 발생하는 현상을 수정합니다.

- Local Notification 을 띄우고 다음번 Schedule Alarm을 설정할 때 과거 시간으로 등록 되지 않도록 주기에 맞는 가까운 미래 시간으로 설정되도록 수정