### PR TITLE
fix: fix getToken crash in android

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotification.java
@@ -134,8 +134,8 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
     @ReactMethod
     public void requestPermissions(Promise promise) {
         final RNPushNotificationJsDelivery fMjsDelivery = mJsDelivery;
-
-        FirebaseMessaging.getInstance().getToken()
+        try {
+            FirebaseMessaging.getInstance().getToken()
                 .addOnCompleteListener(new OnCompleteListener<String>() {
                     @Override
                     public void onComplete(@NonNull Task<String> task) {
@@ -158,6 +158,9 @@ public class RNPushNotification extends ReactContextBaseJavaModule implements Ac
                         promise.reject("E_FAILED_TO_GET_TOKEN", e.getMessage());
                     }
                 });
+        } catch (Exception e) {
+            promise.reject("E_FAILED_TO_GET_TOKEN", e.getMessage());
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
android에서 requestPermissions 함수 안에서 firebase Token 가져올때 크래시 나는 문제를 수정합니다.


https://app.bugsnag.com/radishfiction/radish/errors/63c62a92a3359c0008d7f263?filters[event.since]=30d&filters[error.status]=open
